### PR TITLE
Add `java.base` as non-synthetic require

### DIFF
--- a/src/main/java/io/github/dmlloyd/moduleinfo/ModuleInfoCreator.java
+++ b/src/main/java/io/github/dmlloyd/moduleinfo/ModuleInfoCreator.java
@@ -454,7 +454,9 @@ public class ModuleInfoCreator {
                 Map<String, ModuleRequire> requires = new HashMap<>();
                 if (addMandatory) {
                     log.info("Automatically adding mandatory \"java.base\" dependency");
-                    requires.put("java.base", new ModuleRequire("java.base", null, false, true, true, false));
+                    // We want the `java.base` to be added as non-synthetic
+                    // so that there are no problems to use it with JDK21+ (see https://bugs.openjdk.org/browse/JDK-8299769)
+                    requires.put("java.base", new ModuleRequire("java.base", null, false, false, true, false));
                 }
                 if (moduleInfo != null) {
                     List<ModuleRequire> list = moduleInfo.getRequires();


### PR DESCRIPTION
Hey David,

as you've suggested. Here's that PR. I've tested the change by using a local plugin build in jboss-logging and then used that in the original Hibernate Search build with JDK21 where we discovered it originally. 