### PR TITLE
A few imprvements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -266,11 +266,17 @@ The following properties are supported by the single `generate` goal, which is b
 *Default value is*: `true`
 
 *User property is*: `module-info.add-packages`
-| `<addExports>` | `boolean` | `1.0` | If set to `true`, all packages that do not contain a segment called `_private` or `internal` will be exported to dependents.
+| `<addExports>` | `boolean` | `1.0` | If set to `true`, all packages that do not contain a segment called `\_private`, `private_` or `internal` will be exported to dependents.
+Package filtering can be adjusted with the `exportExcludes` parameter.
 
 *Default value is*: `true`
 
 *User property is*: `module-info.add-exports`
+| `<exportExcludes>` | `String` | `2.2` | If `addExports` (`module-info.add-exports`) is set to `true`, this regexp will be used to determine if the package should be excluded.
+
+*Default value is*: `^.\*\b(internal\|\_private\|private_)\b.*$`
+
+*User property is*: `module-info.export-excludes`
 | `<moduleName>` | `String` | `1.0` | Specify the module name to use.  If not given, a module name is constructed from the project group and artifact ID.
 
 *User property is*: `module-info.module-name`

--- a/README.adoc
+++ b/README.adoc
@@ -92,6 +92,8 @@ Exported packages are described as a list of objects with the following elements
 |===
 | Name | Description
 | `package` | The package name to export, as a string (required)
+| `pattern` | Defines if the `package` is a regular expression, as a boolean (optional), `false` by default.
+Allows to describe multiple packages (matching the pattern) to be exported/opened to the same list of target modules
 | `to` | A list of target module names to export the module to; if not given, the package is exported to all
 dependent modules (optional)
 |===

--- a/src/main/java/io/github/dmlloyd/moduleinfo/ModuleExport.java
+++ b/src/main/java/io/github/dmlloyd/moduleinfo/ModuleExport.java
@@ -7,6 +7,7 @@ public class ModuleExport {
     private List<String> to;
     private boolean synthetic;
     private boolean mandated;
+    private boolean pattern = false;
 
     public ModuleExport() {
     }
@@ -16,6 +17,7 @@ public class ModuleExport {
         this.to = to;
         this.synthetic = synthetic;
         this.mandated = mandated;
+        this.pattern = false;
     }
 
     public String getPackage() {
@@ -48,5 +50,17 @@ public class ModuleExport {
 
     public void setMandated(final boolean mandated) {
         this.mandated = mandated;
+    }
+
+    public boolean isPattern() {
+        return pattern;
+    }
+
+    public void setPattern(boolean pattern) {
+        this.pattern = pattern;
+    }
+
+    public ModuleExport withPackageName(String package_) {
+        return new ModuleExport(package_, to, synthetic, mandated);
     }
 }

--- a/src/main/java/io/github/dmlloyd/moduleinfo/ModuleInfoCreator.java
+++ b/src/main/java/io/github/dmlloyd/moduleinfo/ModuleInfoCreator.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
@@ -342,7 +343,7 @@ public class ModuleInfoCreator {
                         moduleVisitor.visitPackage(packageName.replace('.', '/'));
                     }
                 }
-                Map<String, ModuleExport> exports = new HashMap<>();
+                Map<String, ModuleExport> exports = new TreeMap<>();
                 if (addExports) {
                     Pattern excludedPackages = Pattern.compile(exportExcludes);
                     for (String package_ : packages) {
@@ -392,7 +393,7 @@ public class ModuleInfoCreator {
                     }
                     moduleVisitor.visitExport(export.getPackage().replace('.', '/'), flags, array);
                 }
-                Map<String, ModuleExport> opens = new HashMap<>();
+                Map<String, ModuleExport> opens = new TreeMap<>();
                 if (moduleInfo != null) {
                     List<ModuleExport> moduleInfoOpens = moduleInfo.getOpens();
                     if (moduleInfoOpens != null) {

--- a/src/main/java/io/github/dmlloyd/moduleinfo/ModuleInfoMojo.java
+++ b/src/main/java/io/github/dmlloyd/moduleinfo/ModuleInfoMojo.java
@@ -45,6 +45,9 @@ public class ModuleInfoMojo extends AbstractMojo {
     @Parameter(defaultValue = "true", property = "module-info.add-exports")
     private boolean addExports;
 
+    @Parameter(defaultValue = "^.*\\b(internal|_private|private_)\\b.*$", property = "module-info.export-excludes")
+    private String exportExcludes;
+
     @Parameter(defaultValue = "${project.artifactId}", required = true)
     private String moduleArtifactId;
 
@@ -82,6 +85,7 @@ public class ModuleInfoMojo extends AbstractMojo {
         }
         creator.setAddPackages(addPackages);
         creator.setAddExports(addExports);
+        creator.setExportExcludes(exportExcludes);
         creator.setAddMandatory(addMandatory);
         creator.setDetectUses(detectUses);
         creator.setDetectProvides(detectProvides);


### PR DESCRIPTION
Hey @dmlloyd 
We've been looking into using this plugin in Hibernate Search, and came up with a few possible improvements:

- sorting of exports/opens, since the list of `to`s is already sorted, it would be nice also to have the lists of exports and opens sorted too.
- a filter for automatic package exporting. Currently the plugin would ignore `internal` and `private` packages since some projects can also use `impl` or other names. Having a filter can save some time by not listing the packages explicitly.
- adding an option for an export/open package name be a regexp. We have a use case where we export multiple packages to the same list of target modules, and it would be nice if we could define this without repeating it multiple times.

Let me know if these changes make sense and/or if you have suggestions for the property names or approach in general. Thanks!